### PR TITLE
Disable urllib3's InsecureRequestWarning

### DIFF
--- a/sdk/api/resource.py
+++ b/sdk/api/resource.py
@@ -5,6 +5,7 @@ import json
 import requests
 from requests.auth import HTTPBasicAuth
 
+requests.packages.urllib3.disable_warnings()
 
 class Resource(object):
     """Generic REST resource of the Blueliv's API.


### PR DESCRIPTION
This will stop the API from emitting urllib3's `InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised.` warning.
