### PR TITLE
Improve error logging

### DIFF
--- a/sdk/api/resource.py
+++ b/sdk/api/resource.py
@@ -33,10 +33,9 @@ class Resource(object):
         try:
             r = requests.get(query, verify=False,
                              headers=self.headers, timeout=self.http_timeout)
-            r.raise_for_status
+            r.raise_for_status()
             response = r.json()
-        except Exception as e:
-            logger.error("Error downloading data from: {}"
-                         .format(query))
+        except Exception:
+            logger.exception("Error downloading data from: {}".format(query))
 
         return response


### PR DESCRIPTION
The actual error messages were being eaten. Also, `r.raise_for_status()` wasn't actually being called. `logger.exception()` appends the entire exception and traceback to the log file.
