### PR TITLE
Fix requirements to avoid dependency conflicts

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-requests>=2.4.0,<= 2.5.1
+requests>=2.4.0
 python-dateutil>=2.4.0
 mock==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests>=2.4.0,<= 2.5.1
+requests>=2.4.0
 python-dateutil>=2.4.0


### PR DESCRIPTION
This API SDK works fine with `requests` version higher than 2.5.1